### PR TITLE
Rank Math SEO Compatibility

### DIFF
--- a/includes/forum-compatibility.php
+++ b/includes/forum-compatibility.php
@@ -10,6 +10,7 @@ class AsgarosForumCompatibility {
 
         $this->compatibility_autoptimize();
         $this->compatibility_yoastseo();
+        $this->compatibility_rankmath();
     }
 
     // AUTOPTIMIZE
@@ -41,6 +42,18 @@ class AsgarosForumCompatibility {
                 $wpseo_front = WPSEO_Frontend::get_instance();
                 remove_action('wp_head', array($wpseo_front, 'head'), 1);
             }
+        }
+    }
+
+    // Rank Math
+    function compatibility_rankmath() {
+        add_action( 'wp_head', array( $this, 'comp_rankmath_head' ), 1 );
+    }
+
+    function comp_rankmath_head() {
+        if ($this->asgarosforum->executePlugin) {
+            remove_all_actions( 'rank_math/head' );
+            add_filter( 'rank_math/frontend/remove_credit_notice', '__return_true' );
         }
     }
 }


### PR DESCRIPTION
Dashicons were getting messed up when the Rank Math plugin was made active.

Along with that, the meta tags were getting repeated. Since Asgaros Forum plugin adds the description and the OG tags, the forum pages were showing repeated tags.

This commit fixes them all.

Once merged and released, please submit your plugin here:
https://rankmath.com/contact/ (Compatible Product Submission)

So, we can list it here and linkback to you:
https://rankmath.com/compatibility/