### PR TITLE
Allow custom pages to be added to forum

### DIFF
--- a/includes/forum.php
+++ b/includes/forum.php
@@ -437,6 +437,10 @@ class AsgarosForum {
                     $this->current_view = 'overview';
                 }
             break;
+	        case apply_filters('asgarosforum_custom_page_'.$this->current_view.'_switch','custom'):
+	        	// Allow for custom view
+		        $this->current_view = apply_filters('asgarosforum_custom_page_'.$this->current_view.'_switch','custom');
+		        break;
             default:
                 $this->current_view = 'overview';
             break;
@@ -637,7 +641,7 @@ class AsgarosForum {
             }
         }
 
-        return $mainTitle;
+	    return apply_filters('asgarosforum_mainTitle', $mainTitle, $this);// Filter the main page title
     }
 
     // Adds the current page to a string.
@@ -761,6 +765,10 @@ class AsgarosForum {
                     case 'reports':
                         $this->reports->show_reports();
                     break;
+	                case apply_filters('asgarosforum_custom_page_'.$this->current_view.'_switch','custom'):
+	                	// render the custom page
+		                do_action('asgarosforum_custom_page_'.$this->current_view.'_content',$this);
+	                break;
                     default:
                         $this->overview();
                     break;


### PR DESCRIPTION
I have added a few filters to allow a custom page to be rendered within the asgaros layout.

The custom page can then be created in the theme functions.php file like so.
`

    add_action('asgarosforum_custom_header_menu','add_my_forum_custom_to_forum_nav');
    function add_my_forum_custom_to_forum_nav(){
	    echo '<a class="" href="/forum/my-custom/">My custom</a>';// you may need to change the href
    }

    add_filter('asgarosforum_custom_page_my-custom_switch','add_my_forum_custom_to_forum_switch');
    function add_my_forum_custom_to_forum_switch(){
        return 'my-custom';
    }

    add_action('asgarosforum_custom_page_my-custom_content','add_my_forum_custom_to_forum_content');
    function add_my_forum_custom_to_forum_content($forum){
        echo 'Custome Page content here';
    }

    add_filter('asgarosforum_mainTitle','add_my_forum_custom_change_main_title',10,2);
    function add_my_forum_custom_change_main_title($title,$forum){
        if($forum->current_view=='my-custom'){
    	    return 'My custom';
        }
        return $title;
    }
`


I hope you find these useful also.