### PR TITLE
Change in the 'show_history()' function

### DIFF
--- a/includes/forum-profile.php
+++ b/includes/forum-profile.php
@@ -157,17 +157,8 @@ class AsgarosForumProfile {
         }
     }
 
-    public function show_history() {
-        $user_id = $this->asgarosforum->current_element;
-        $userData = $this->get_user_data($user_id);
-
-        if ($userData) {
-            if ($this->hideProfileLink()) {
-                _e('You need to login to have access to profiles.', 'asgaros-forum');
-            } else {
-                $this->show_profile_header($userData);
-                $this->show_profile_navigation($userData);
-
+    public function show_user_history($user_id) {
+        // Shows the history of user posts in the table-like format
                 echo '<div id="profile-layer">';
                     $posts = $this->get_post_history_by_user($user_id, true);
 
@@ -205,6 +196,21 @@ class AsgarosForumProfile {
                         }
                     }
                 echo '</div>';
+
+    }
+
+    public function show_history() {
+        $user_id = $this->asgarosforum->current_element;
+        $userData = $this->get_user_data($user_id);
+
+        if ($userData) {
+            if ($this->hideProfileLink()) {
+                _e('You need to login to have access to profiles.', 'asgaros-forum');
+            } else {
+                $this->show_profile_header($userData);
+                $this->show_profile_navigation($userData);
+
+                $this->show_user_history($user_id);
             }
         } else {
             _e('This user does not exist.', 'asgaros-forum');


### PR DESCRIPTION
Hello,

I would like to propose the change in the `show_history()` function definition: the section responsible for printing the table I would extract to the public function `show_user_history($user_id)`

**Advantages**:
1. the code of 'show_history' looks more comprehensive and clean
1. no need to change any other code
1. code of 'show_user_history' can help (in the future) to solve issues like: <br><https://www.asgaros.de/support/topic/ultimate-member/?part=3#postid-4409>

Kind regards,
Maciej