### PR TITLE
Fix line break issue at header menu

### DIFF
--- a/skin/style.css
+++ b/skin/style.css
@@ -741,7 +741,7 @@
     color: #fff !important;
     border-left: 1px solid #054d98;
     line-height: 44px;
-    display: inline; /* comp */
+    display: inline-block; /* comp */
     margin: 0; /* comp */
     text-align: left; /* comp */
     position: static; /* comp */


### PR DESCRIPTION
If new menu entries are inserted in the header menu, no line break is created. This also bug occurs on smaller devices without adding new entries. The change prevents this and all menu entries are displayed properly.

Before:
![image](https://user-images.githubusercontent.com/62839501/80992271-768bc780-8e63-11ea-8cb8-21e8747dce9b.png)

After:
![image](https://user-images.githubusercontent.com/62839501/80992353-9327ff80-8e63-11ea-8a24-d2171e2f5378.png)
