### PR TITLE
Width of input field in forum-search

### DIFF
--- a/skin/style.css
+++ b/skin/style.css
@@ -857,7 +857,7 @@
     padding: 0;
     border: 0;
     background-color: inherit;
-    width: 190px;
+    width: calc(100% - 40px);;
     height: initial; /* comp */
     font-size: 13px;
     line-height: normal;


### PR DESCRIPTION
Use calc() to get a full width input field.

Befor:
 ![Screenshot_20200523_142757](https://user-images.githubusercontent.com/62839501/82724860-305bb280-9d03-11ea-9181-dddfd8f083f5.png)

After:
![Screenshot_20200523_142848](https://user-images.githubusercontent.com/62839501/82724875-3782c080-9d03-11ea-9f6e-b54f5a28ea3d.png)


