### PR TITLE
Styling for multi line menu

### DIFF
--- a/skin/style.css
+++ b/skin/style.css
@@ -731,8 +731,7 @@
 }
 #af-wrapper #forum-navigation,
 #af-wrapper #forum-navigation-mobile {
-    display: block;
-    float: left;
+    display: inline;
     text-align: left; /* comp */
 }
 #af-wrapper #forum-navigation a,


### PR DESCRIPTION
Search field was always in seperate line if there are more the two lines of menu entries.

Before:
![Screenshot_20200530_161327](https://user-images.githubusercontent.com/62839501/83324644-02411a00-a291-11ea-9e4b-a582d9cbc44d.png)

After:
![Screenshot_20200530_161439](https://user-images.githubusercontent.com/62839501/83324647-05d4a100-a291-11ea-9169-9a7f7f4e5a3e.png)
