### PR TITLE
Add custom classes to body tag

### DIFF
--- a/includes/forum-search.php
+++ b/includes/forum-search.php
@@ -93,6 +93,11 @@ class AsgarosForumSearch {
                 $categoriesFilter[] = $category->term_id;
             }
 
+            // Do not execute a search-query when no categories are accessible.
+            if (empty($categoriesFilter)) {
+                return false;
+            }
+
             $where = 'AND f.parent_id IN ('.implode(',', $categoriesFilter).')';
 
             $start = $this->asgarosforum->current_page * $this->asgarosforum->options['topics_per_page'];

--- a/includes/forum.php
+++ b/includes/forum.php
@@ -601,8 +601,11 @@ class AsgarosForum {
     // Generate Classes for Body Tag
     function add_class_to_body($classes) {
 
-        $classes[] = 'asgaros-forum';
-        $classes[] = 'asgaros-forum-' . $this->current_view;
+        // Check if current view is set
+        if ($this->current_view){
+            $classes[] = 'asgaros-forum';
+            $classes[] = 'asgaros-forum-' . $this->current_view;
+        }
 
         return $classes;
     }

--- a/includes/forum.php
+++ b/includes/forum.php
@@ -197,6 +197,9 @@ class AsgarosForum {
         add_action('wp', array($this, 'prepare'));
         add_action('wp_enqueue_scripts', array($this, 'enqueue_css_js'), 10);
 
+        // add classes to body tag
+        add_filter( 'body_class', array($this, 'add_class_to_body'));
+
         // Add filters for modifying the title of the page.
         add_filter('wp_title', array($this, 'change_wp_title'), 100, 3);
         add_filter('document_title_parts', array($this, 'change_document_title_parts'), 100);
@@ -593,6 +596,15 @@ class AsgarosForum {
         }
 
         do_action('asgarosforum_enqueue_css_js');
+    }
+
+    // Generate Classes for Body Tag
+    function add_class_to_body($classes) {
+
+        $classes[] = 'asgaros-forum';
+        $classes[] = 'asgaros-forum-' . $this->current_view;
+
+        return $classes;
     }
 
     // Gets the pages main title.

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,7 @@ You can find a list of available hooks and filters on this site:
 6. Manage general options.
 
 == Changelog ==
+* Fixed: Do not execute a search-query when no categories are accessible
 * Fixed: Minor display issues
 * Changed: Misleading strings
 = 1.15.4 =

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,7 @@ You can find a list of available hooks and filters on this site:
 6. Manage general options.
 
 == Changelog ==
+* Added: Custom classes for body tag
 * Fixed: Do not execute a search-query when no categories are accessible
 * Fixed: Minor display issues
 * Changed: Misleading strings


### PR DESCRIPTION
Hey Thomas, 

someone in the Forum asked for a [specific class in the body tag for a single topic](https://www.asgaros.de/support/topic/single-topic-doesnt-have-a-class/). 

I think that would be a big advantage for a lot users to be able to use these kind of selectors for their styling. So I added a two new classes to the body tag:
- asgaros-forum
- asgaros-forum-{actual_view}
