### PR TITLE
Fix: get_link() usable with REST API

### DIFF
--- a/includes/forum-rewrite.php
+++ b/includes/forum-rewrite.php
@@ -223,7 +223,12 @@ class AsgarosForumRewrite {
 
     // Builds and returns a requested link.
     function get_link($type, $element_id = false, $additional_parameters = false, $appendix = '', $escape_url = true) {
-        // Only generate a link when that type is available.
+        // Make function available while using the REST API
+	if (empty($this->links)){
+            $this->set_links();
+        }
+	    
+	// Only generate a link when that type is available.
         if (isset($this->links[$type])) {
             // Initialize the base-link.
             $link = $this->links[$type];


### PR DESCRIPTION
While using the REST API it was not possible to use the get_link function, because $links were not set.