### PR TITLE
Fix bulk action

### DIFF
--- a/includes/forum-permissions.php
+++ b/includes/forum-permissions.php
@@ -17,17 +17,20 @@ class AsgarosForumPermissions {
         add_action('manage_users_custom_column', array($this, 'manage_users_custom_column'), 10, 3);
 
         // Filtering users list in administration by forum role.
-		add_filter('views_users', array($this, 'permission_views'), 10);
+        add_filter('views_users', array($this, 'permission_views'), 10);
         add_action('pre_user_query', array($this, 'permission_user_query'));
 
-        // Bulk edit inside the users list.
-        add_filter('bulk_actions-users', array($this, 'bulk_actions_users'), 10);
-        add_filter('handle_bulk_actions-users', array($this, 'handle_bulk_actions_users'), 10, 3);
-        add_action('admin_notices', array($this, 'bulk_actions_admin_notices'));
 	}
 
     public function initialize() {
         $this->currentUserID = get_current_user_id();
+
+        if($this->isAdministrator($this->currentUserID)){
+            // Bulk edit inside the users list.
+            add_filter('bulk_actions-users', array($this, 'bulk_actions_users'), 10);
+            add_filter('handle_bulk_actions-users', array($this, 'handle_bulk_actions_users'), 10, 3);
+            add_action('admin_notices', array($this, 'bulk_actions_admin_notices'));
+        }
     }
 
     public function isSiteAdministrator($user_id = false) {

--- a/includes/forum-permissions.php
+++ b/includes/forum-permissions.php
@@ -25,7 +25,7 @@ class AsgarosForumPermissions {
     public function initialize() {
         $this->currentUserID = get_current_user_id();
 
-        if($this->isAdministrator($this->currentUserID)){
+        if ($this->isAdministrator($this->currentUserID)) {
             // Bulk edit inside the users list.
             add_filter('bulk_actions-users', array($this, 'bulk_actions_users'), 10);
             add_filter('handle_bulk_actions-users', array($this, 'handle_bulk_actions_users'), 10, 3);

--- a/includes/forum-usergroups.php
+++ b/includes/forum-usergroups.php
@@ -27,7 +27,7 @@ class AsgarosForumUserGroups {
     public function initialize() {
         self::initializeTaxonomy();
 
-        if(self::$asgarosforum->permissions->isAdministrator(get_current_user_id())) {
+        if (self::$asgarosforum->permissions->isAdministrator(get_current_user_id())) {
             // Bulk edit inside the users list.
             add_filter('bulk_actions-users', array($this, 'bulk_actions_users'), 20);
             add_filter('handle_bulk_actions-users', array($this, 'handle_bulk_actions_users'), 10, 3);

--- a/includes/forum-usergroups.php
+++ b/includes/forum-usergroups.php
@@ -20,17 +20,19 @@ class AsgarosForumUserGroups {
 		add_filter('views_users', array($this, 'views'), 20);
         add_action('pre_user_query', array($this, 'user_query'));
 
-		// Bulk edit inside the users list.
-        add_filter('bulk_actions-users', array($this, 'bulk_actions_users'), 20);
-        add_filter('handle_bulk_actions-users', array($this, 'handle_bulk_actions_users'), 10, 3);
-        add_action('admin_notices', array($this, 'bulk_actions_admin_notices'));
-
-        // Certain actions when a new user registers.
+		// Certain actions when a new user registers.
         add_action('user_register', array($this, 'add_new_user_to_usergroups'), 10, 1);
     }
 
     public function initialize() {
         self::initializeTaxonomy();
+
+        if(self::$asgarosforum->permissions->isAdministrator(get_current_user_id())) {
+            // Bulk edit inside the users list.
+            add_filter('bulk_actions-users', array($this, 'bulk_actions_users'), 20);
+            add_filter('handle_bulk_actions-users', array($this, 'handle_bulk_actions_users'), 10, 3);
+            add_action('admin_notices', array($this, 'bulk_actions_admin_notices'));
+        }
     }
 
     public static function initializeTaxonomy() {

--- a/readme.txt
+++ b/readme.txt
@@ -87,7 +87,7 @@ You can find a list of available hooks and filters on this site:
 6. Manage general options.
 
 == Changelog ==
-* Fixed: Permissions for bulk actions
+* Fixed: Show bulk-actions for user-roles/groups to administrators only
 * Performance improvements and code optimizations
 = 1.15.8 =
 * Added: asgarosforum_filter_meta_post_type filter

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,7 @@ You can find a list of available hooks and filters on this site:
 6. Manage general options.
 
 == Changelog ==
+* Fixed: Permissions for bulk actions
 * Performance improvements and code optimizations
 = 1.15.8 =
 * Added: asgarosforum_filter_meta_post_type filter


### PR DESCRIPTION
Remove Bulk actions for non-admins in user list (wp-admin).

Close #306 